### PR TITLE
Add MQTT Topic Listener To ml-backend

### DIFF
--- a/aws-backend/iam.tf
+++ b/aws-backend/iam.tf
@@ -1,20 +1,38 @@
+
 resource "aws_iam_role" "lambda_role" {
   name = "lambda_execution"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Principal = {
-        Service = "lambda.amazonaws.com"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
       }
-      Action = "sts:AssumeRole"
-    }]
+    ]
   })
 }
 
-resource "aws_iam_policy_attachment" "lambda_basic_execution" {
-  name       = "lambda_basic_execution"
-  roles      = [aws_iam_role.lambda_role.name]
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+resource "aws_iam_policy" "iot_publish_policy" {
+  name        = "iot_publish_policy"
+  description = "Policy allowing Lambda to publish to user-requests topic in IoT Core"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "iot:Publish"
+        Resource = "arn:aws:iot:us-east-1:${data.aws_caller_identity.current.account_id}:topic/user-requests"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.iot_publish_policy.arn
 }

--- a/aws-backend/lambda_api/main.py
+++ b/aws-backend/lambda_api/main.py
@@ -1,11 +1,43 @@
 import json
 import boto3
+import os
+
+# Initialize AWS IoT Data client
+iot_client = boto3.client('iot-data', region_name=os.environ.get("AWS_REGION", "us-east-1"))
+
+# Define the MQTT topic
+MQTT_TOPIC = "user-requests"
 
 def lambda_handler(event, context):
-    return {
-        "statusCode": 200,
-        "body": json.dumps({
-            "message": "Hello from Python Lambda!",
-            "event": event
-        })
-    }
+    """
+    AWS Lambda handler function to publish a message to an MQTT topic in AWS IoT Core.
+    """
+    try:
+        # Construct the message payload
+        message_payload = {
+            "requestId": context.aws_request_id,
+            "message": event["pathParameters"]["color"],
+            "event": event["body"]
+        }
+
+        # Publish the message to the MQTT topic
+        response = iot_client.publish(
+            topic=MQTT_TOPIC,
+            qos=1,  # QoS Level (0: At most once, 1: At least once)
+            payload=json.dumps(message_payload)
+        )
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps({
+                "message": f"Message published to MQTT topic: {MQTT_TOPIC}",
+                "response": response
+            })
+        }
+
+    except Exception as e:
+        print(f"Error publishing to MQTT: {e}")
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"error": str(e)})
+        }

--- a/aws-backend/lambda_api/main.py
+++ b/aws-backend/lambda_api/main.py
@@ -16,7 +16,7 @@ def lambda_handler(event, context):
         # Construct the message payload
         message_payload = {
             "requestId": context.aws_request_id,
-            "message": event["pathParameters"]["color"],
+            "color": event["pathParameters"]["color"],
             "event": event["body"]
         }
 

--- a/aws-backend/main.tf
+++ b/aws-backend/main.tf
@@ -8,5 +8,5 @@ module "api_gw" {
   source = "./modules/api_gateway"
 
   api_lambda_invoke_arn = module.lambda.api_lambda_invoke_arn
-  api_lambda_name = module.lambda.api_lambda_name
+  api_lambda_name       = module.lambda.api_lambda_name
 }

--- a/aws-backend/modules/api_gateway/v1_path/get_test.tf
+++ b/aws-backend/modules/api_gateway/v1_path/get_test.tf
@@ -1,11 +1,11 @@
 resource "aws_apigatewayv2_integration" "lambda" {
   api_id           = var.api_gw_http_id
   integration_type = "AWS_PROXY"
-  integration_uri = var.api_lambda_invoke_arn
+  integration_uri  = var.api_lambda_invoke_arn
 }
 
 resource "aws_apigatewayv2_route" "lambda" {
   api_id    = var.api_gw_http_id
-  route_key = "GET /v1/lambda"
+  route_key = "GET /v1/lambda/{color}"
   target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
 }

--- a/aws-backend/modules/api_gateway/v1_path/variables.tf
+++ b/aws-backend/modules/api_gateway/v1_path/variables.tf
@@ -1,7 +1,7 @@
-variable api_lambda_invoke_arn {
-    type = string
+variable "api_lambda_invoke_arn" {
+  type = string
 }
 
-variable api_gw_http_id {
-    type = string
+variable "api_gw_http_id" {
+  type = string
 }

--- a/aws-backend/modules/api_gateway/variables.tf
+++ b/aws-backend/modules/api_gateway/variables.tf
@@ -1,7 +1,7 @@
-variable api_lambda_invoke_arn {
-    type = string
+variable "api_lambda_invoke_arn" {
+  type = string
 }
 
-variable api_lambda_name {
-    type = string
+variable "api_lambda_name" {
+  type = string
 }

--- a/aws-backend/modules/lambda/outputs.tf
+++ b/aws-backend/modules/lambda/outputs.tf
@@ -1,7 +1,7 @@
 output "api_lambda_invoke_arn" {
-    value = aws_lambda_function.api_lambda.invoke_arn
+  value = aws_lambda_function.api_lambda.invoke_arn
 }
 
 output "api_lambda_name" {
-    value = aws_lambda_function.api_lambda.function_name
+  value = aws_lambda_function.api_lambda.function_name
 }

--- a/aws-backend/providers.tf
+++ b/aws-backend/providers.tf
@@ -11,3 +11,5 @@ terraform {
 provider "aws" {
   region = "us-east-1"
 }
+
+data "aws_caller_identity" "current" {}


### PR DESCRIPTION
This is the final step in routing user requests to the backend with AWS infrastructure. Here we are adding a MQTT topic listener that will listen for requests on the MQTT topic named, `user-requests`, once a request comes in our code will unpack the request and change the `color` variable that our model is currently using. 

The listener can be enabled or disabled with the `MQTT_TOPIC_ENABLED` flag, that is currently within the `face-detection.py` file. 

In order to enable this MQTT listener to connect the ml-backend to AWS you will need certificates that can be obtained by contacting @scuruchima1. These certificates are sensitive info and cannot be committed to the repository as it allows for a direct connection to AWS.