### PR TITLE
provision AWS S3 and Cloudfront for react web app

### DIFF
--- a/aws-backend/main.tf
+++ b/aws-backend/main.tf
@@ -10,3 +10,16 @@ module "api_gw" {
   api_lambda_invoke_arn = module.lambda.api_lambda_invoke_arn
   api_lambda_name       = module.lambda.api_lambda_name
 }
+
+module "web_app_s3" {
+  source = "./modules/s3"
+
+  cloudfront_arn = module.web_app_cloudfront.cloudfront_arn
+}
+
+module "web_app_cloudfront" {
+  source = "./modules/cloudfront"
+
+  # web_bucket_origin_id = module.web_app_s3.web_bucket_origin_id
+  web_bucket_region_domain_name = module.web_app_s3.web_bucket_region_domain_name
+}

--- a/aws-backend/modules/cloudfront/cloudfront.tf
+++ b/aws-backend/modules/cloudfront/cloudfront.tf
@@ -1,0 +1,105 @@
+locals {
+  s3_origin_id = "myS3Origin"
+}
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  origin {
+    domain_name              = var.web_bucket_region_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.bucket_control.id
+    origin_id                = local.s3_origin_id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+#   logging_config {
+#     include_cookies = false
+#     bucket          = "mylogs.s3.amazonaws.com"
+#     prefix          = "myprefix"
+#   }
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior with precedence 0
+  ordered_cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  # Cache behavior with precedence 1
+  ordered_cache_behavior {
+    path_pattern     = "/content/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_200"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+
+resource "aws_cloudfront_origin_access_control" "bucket_control" {
+  name                              = "bucket-control"
+  description                       = "Bucket Access Policy for eoh web app"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}

--- a/aws-backend/modules/cloudfront/outputs.tf
+++ b/aws-backend/modules/cloudfront/outputs.tf
@@ -1,0 +1,3 @@
+output "cloudfront_arn" {
+    value = aws_cloudfront_distribution.s3_distribution.arn
+}

--- a/aws-backend/modules/cloudfront/variables.tf
+++ b/aws-backend/modules/cloudfront/variables.tf
@@ -1,0 +1,3 @@
+variable "web_bucket_region_domain_name" {
+    type = string
+}

--- a/aws-backend/modules/s3/outputs.tf
+++ b/aws-backend/modules/s3/outputs.tf
@@ -1,0 +1,7 @@
+# output "web_bucket_origin_id" {
+#     value = aws_s3_bucket.web_bucket.origin
+# }
+
+output "web_bucket_region_domain_name" {
+    value = aws_s3_bucket.web_bucket.bucket_regional_domain_name
+}

--- a/aws-backend/modules/s3/s3.tf
+++ b/aws-backend/modules/s3/s3.tf
@@ -1,0 +1,42 @@
+resource "aws_s3_bucket" "web_bucket" {
+  bucket = "eoh-web-app-bucket"
+}
+
+# resource "aws_s3_object" "react_build" {
+#   for_each = fileset("../../react-frontend/build", "**/*")
+
+#   bucket = aws_s3_bucket.web_bucket.id
+#   key    = each.value
+#   source = "../../react-frontend/build/${each.value}"
+
+#   etag = filemd5("../../react-frontend/build/${each.value}")  # Ensures updates if files change
+
+#   # This forces Terraform to re-upload files every time
+#   metadata = {
+#     force_update = timestamp()
+#   }
+# }
+
+resource "aws_s3_bucket_policy" "web_bucket_policy" {
+  bucket = aws_s3_bucket.web_bucket.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+        {
+            "Sid": "AllowCloudFrontServicePrincipal",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "cloudfront.amazonaws.com"
+            },
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::${aws_s3_bucket.web_bucket.id}/*",
+            "Condition": {
+                "StringEquals": {
+                    "AWS:SourceArn": "${var.cloudfront_arn}"
+                }
+            }
+        }
+    ]
+  })
+}
+

--- a/aws-backend/modules/s3/variables.tf
+++ b/aws-backend/modules/s3/variables.tf
@@ -1,0 +1,3 @@
+variable "cloudfront_arn" {
+    type = string
+}


### PR DESCRIPTION
I have put up AWS S3 (file storage) and Cloudfront resources so that our react web app frontend can have a live website. This website can be accessed at https://d1sgrkfj1bwr8d.cloudfront.net. 

This currently works by putting build files (the web app) into AWS S3 and then routing web traffic to access the files via AWS Cloudfront.

More on the approach can be found here 
https://aws.amazon.com/blogs/networking-and-content-delivery/amazon-s3-amazon-cloudfront-a-match-made-in-the-cloud/