### PR TITLE
Build react web app and upload to S3

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -45,6 +45,7 @@ jobs:
 
       # ---- Upload React Build to S3 ----
       - name: Upload Build to S3
+        if: github.ref == 'refs/heads/main'
         run: aws s3 sync react-frontend/build/ s3://$S3_BUCKET_NAME/ --delete
 
       # ---- OpenTofu Deployment ----

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,8 +1,7 @@
 name: OpenTofu Apply
 
 on:
-  workflow_dispatch:  # This will allow manual triggering
-
+  workflow_dispatch:  # Allows manual triggering
   push:
     branches:
       - main
@@ -18,7 +17,8 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: "us-east-1"  # Hardcoding the region
+      AWS_DEFAULT_REGION: "us-east-1"
+      S3_BUCKET_NAME: "eoh-web-app-bucket"  
 
     steps:
       - name: Checkout repository
@@ -29,18 +29,38 @@ jobs:
         with:
           tofu_version: 1.6.0
 
-      - name: Change to AWS Backend Directory
-        run: cd aws-backend
+      # ---- React Build Step ----
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18  
 
+      - name: Install Dependencies
+        working-directory: react-frontend
+        run: npm install
+
+      - name: Build React App
+        working-directory: react-frontend
+        run: npm run build
+
+      # ---- Upload React Build to S3 ----
+      - name: Upload Build to S3
+        run: aws s3 sync react-frontend/build/ s3://$S3_BUCKET_NAME/ --delete
+
+      # ---- OpenTofu Deployment ----
       - name: Initialize OpenTofu
-        run: cd aws-backend && tofu init
+        working-directory: aws-backend
+        run: tofu init
 
       - name: Validate OpenTofu Configuration
-        run: cd aws-backend && tofu validate
+        working-directory: aws-backend
+        run: tofu validate
 
       - name: Generate Execution Plan
-        run: cd aws-backend && tofu plan -out=tfplan
+        working-directory: aws-backend
+        run: tofu plan -out=tfplan
 
       - name: Apply OpenTofu Changes
         if: github.ref == 'refs/heads/main'
-        run: cd aws-backend && tofu apply -auto-approve tfplan
+        working-directory: aws-backend
+        run: tofu apply -auto-approve tfplan


### PR DESCRIPTION
This PR will allow our terraform pipeline to build and upload our react web app to AWS to ensure that any changes to the main branch are immediately reflected on the live website.