### PR TITLE
fixed duplicated pipelines

### DIFF
--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -1,6 +1,11 @@
 name: JavaScript Build & Lint
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "react_frontend/**"
 
 jobs:
   js-build:

--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - "react_frontend/**"
+  push:
+    branches:
+      - main
 
 jobs:
   js-build:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - "ml_backend/**"
       - "aws_backend/**"
+  push:
+    branches:
+      - main
 
 jobs:
   ml-backend-tests:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,12 @@
 name: Python Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "ml_backend/**"
+      - "aws_backend/**"
 
 jobs:
   ml-backend-tests:

--- a/.github/workflows/react-build.yml
+++ b/.github/workflows/react-build.yml
@@ -7,6 +7,9 @@ on:
       - main
     paths:
       - "react_frontend/**"
+  push:
+    branches:
+      - main
 
 jobs:
   react-build:
@@ -37,6 +40,5 @@ jobs:
         run: npm run build
 
       - name: Upload Build to AWS S3 (Only on main)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: aws s3 sync react-frontend/build/ s3://$S3_BUCKET_NAME/ --delete
-        
+        if: github.ref == 'refs/heads/main'
+        run: aws s3 sync react_frontend/build/ s3://$S3_BUCKET_NAME/ --delete

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -7,6 +7,9 @@ on:
       - main
     paths:
       - "aws_backend/**"
+  push:
+    branches:
+      - main
 
 jobs:
   opentofu:
@@ -40,6 +43,6 @@ jobs:
         run: tofu plan -out=tfplan
 
       - name: Apply OpenTofu Changes (Only on main)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         working-directory: aws_backend
         run: tofu apply -auto-approve tfplan


### PR DESCRIPTION
Let's reduce the amount of pipelines that run on every pull request. Currently every pull request generates 2 of `JavaScript Build & Lint` and 2 of `Python Tests` pipelines, since we are triggering the pipeline on push and pull request. 

By only triggering the pipeline of pull request and on push to main, the pipeline only runs when
- a pull request is raised
- a pull request is updated
- a pull request is merged into main

By also targeting specific folder paths for our pipeline triggers we can reduce the amount of extra pipeline runs on all newly raised pull requests.