### PR TITLE
specify pipeline on push file path trigger

### DIFF
--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "react_frontend/**"
 
 jobs:
   js-build:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "ml_backend/**"
+      - "aws_backend/**"
 
 jobs:
   ml-backend-tests:

--- a/.github/workflows/react-build.yml
+++ b/.github/workflows/react-build.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "react_frontend/**"
 
 jobs:
   react-build:

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "aws_backend/**"
 
 jobs:
   opentofu:


### PR DESCRIPTION
Currently all pipelines are running when we are pushing commits to main. Lets ensure that only pipelines for corresponding changed files are ran. 

For all pipelines I have made the "on push" file path trigger the same as the "on pull request" file path trigger that was previously there.